### PR TITLE
Add display_name to user payloads

### DIFF
--- a/test/controllers/invite_controller_test.exs
+++ b/test/controllers/invite_controller_test.exs
@@ -41,7 +41,8 @@ defmodule Api.InviteControllerTest do
       "host" => %{
         "id" => user.id,
         "first_name" => user.first_name,
-        "last_name" => user.last_name
+        "last_name" => user.last_name,
+        "display_name" => "#{user.first_name} #{user.last_name}"
       },
       "invitee" => nil,
       "open" => false

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -33,6 +33,7 @@ defmodule Api.UserControllerTest do
       "id" => user.id,
       "first_name" => user.first_name,
       "last_name" => user.last_name,
+      "display_name" => "#{user.first_name} #{user.last_name}",
       "birthday" => user.birthday,
       "employment_status" => user.employment_status,
       "college" => user.college,
@@ -46,6 +47,30 @@ defmodule Api.UserControllerTest do
         "name" => user.team.name
       }
     }
+  end
+
+  test "display name from email if there's no first and last name", %{conn: conn} do
+    user = create_user(%{first_name: nil, last_name: nil, email: "johndoe@example.com", password: "password"})
+
+    conn = get conn, user_path(conn, :show, user)
+
+    assert json_response(conn, 200)["data"]["display_name"] == "johndoe"
+  end
+
+  test "display_name from first name if there's no last name", %{conn: conn} do
+    user = create_user(%{first_name: "john", last_name: nil, email: "johndoe@example.com", password: "password"})
+
+    conn = get conn, user_path(conn, :show, user)
+
+    assert json_response(conn, 200)["data"]["display_name"] == "john"
+  end
+
+  test "display_name from first and last name if they're present", %{conn: conn} do
+    user = create_user(%{first_name: "john", last_name: "doe", email: "johndoe@example.com", password: "password"})
+
+    conn = get conn, user_path(conn, :show, user)
+
+    assert json_response(conn, 200)["data"]["display_name"] == "john doe"
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -16,6 +16,7 @@ defmodule Api.UserView do
       id: user.id,
       first_name: user.first_name,
       last_name: user.last_name,
+      display_name: display_name(user),
       birthday: user.birthday,
       bio: user.bio,
       github_handle: user.github_handle,
@@ -32,7 +33,8 @@ defmodule Api.UserView do
     %{
       id: user.id,
       first_name: user.first_name,
-      last_name: user.last_name
+      last_name: user.last_name,
+      display_name: display_name(user)
     }
   end
 
@@ -43,6 +45,7 @@ defmodule Api.UserView do
         email: user.email,
         first_name: user.first_name,
         last_name: user.last_name,
+        display_name: display_name(user),
         birthday: user.birthday,
         bio: user.bio,
         github_handle: user.github_handle,
@@ -56,4 +59,8 @@ defmodule Api.UserView do
       }
     }
   end
+
+  def display_name(%{first_name: nil, last_name: nil, email: email}), do: List.first(String.split(email, "@", parts: 2))
+  def display_name(%{first_name: first_name, last_name: nil}), do: "#{first_name}"
+  def display_name(%{first_name: first_name, last_name: last_name}), do: "#{first_name} #{last_name}"
 end


### PR DESCRIPTION
Add `display_name` to user responses. It's comprised of `first_name + last_name` if they are present, `first_name` if `last_name` is missing or the email username in case `first_name` and `last_name` are missing.