### PR TITLE
Fix sync problems between email and ID invites

### DIFF
--- a/test/controllers/admin/admin_invite_controller_test.exs
+++ b/test/controllers/admin/admin_invite_controller_test.exs
@@ -1,0 +1,39 @@
+defmodule Api.Admin.InviteControllerTest do
+  use Api.ConnCase
+
+  alias Api.{Invite, Repo}
+  alias Guardian.{Permissions}
+
+  setup %{conn: conn} do
+    admin = create_admin()
+    {:ok, jwt, _} =
+      Guardian.encode_and_sign(admin, :token, perms: %{admin: Permissions.max})
+
+    {:ok, %{
+      admin: admin,
+      jwt: jwt,
+      conn: put_req_header(conn, "content-type", "application/json")
+    }}
+  end
+
+  test "sync invites work", %{conn: conn, jwt: jwt, admin: admin} do
+    owner = create_user()
+    team = create_team(owner)
+    user = create_user()
+
+
+    %{id: id1} = create_invite(%{host_id: owner.id, team_id: team.id, email: user.email})
+    %{id: id2} = create_invite(%{host_id: owner.id, team_id: team.id, email: admin.email})
+
+    conn = conn
+    |> put_req_header("authorization", "Bearer #{jwt}")
+    |> post(admin_invite_path(conn, :sync))
+
+    invite1 = Repo.get(Invite, id1)
+    invite2 = Repo.get(Invite, id2)
+
+    assert response(conn, 204)
+    assert invite1.invitee_id == user.id
+    assert invite2.invitee_id == admin.id
+  end
+end

--- a/web/controllers/admin/admin_invite_controller.ex
+++ b/web/controllers/admin/admin_invite_controller.ex
@@ -1,0 +1,14 @@
+defmodule Api.Admin.InviteController do
+  use Api.Web, :controller
+
+  alias Api.{InviteActions, Controller.Errors}
+  alias Guardian.Plug.{EnsureAuthenticated, EnsurePermissions}
+
+  plug EnsureAuthenticated, [handler: Errors]
+  plug EnsurePermissions, [handler: Errors, admin: ~w(full)]
+
+  def sync(conn, _params) do
+    InviteActions.sync()
+    send_resp(conn, :no_content, "")
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -38,6 +38,7 @@ defmodule Api.Router do
 
       get "/stats", Admin.StatsController, :stats
       delete "/teams/:id/remove/:user_id", Admin.TeamController, :remove
+      post "/invites/sync", Admin.InviteController, :sync
     end
   end
 end


### PR DESCRIPTION
If a user was registered in the application and was invited by the
email instead of his ID, the invite wouldn’t be associated with his
account. This commit adds that syncing mechanism and an admin endpoint
to sync the old invites.