### PR TITLE
Make role order deterministic

### DIFF
--- a/web/actions/stats_actions.ex
+++ b/web/actions/stats_actions.ex
@@ -4,7 +4,12 @@ defmodule Api.StatsActions do
   alias Api.{Project, Repo, Team, TeamMember, User, Workshop, WorkshopAttendance}
 
   def stats do
-    roles = from(u in User, group_by: :role, select: %{role: u.role, total: count(u.id)})
+    roles = from(
+      u in User,
+      group_by: :role,
+      order_by: :role,
+      select: %{role: u.role, total: count(u.id)}
+    )
     applied_teams = from t in Team, where: t.applied == true
     applied_users = from u in TeamMember,
       join: t in assoc(u, :team),


### PR DESCRIPTION
If I reverse the ordering, the test fails. Since we weren't definig any order
before, the test flaked every once in a while. Since we don't have enough
records for the sort to be a problem, this seems like an acceptable solution.