### PR TITLE
Remove unused variable

### DIFF
--- a/web/actions/session_actions.ex
+++ b/web/actions/session_actions.ex
@@ -11,7 +11,7 @@ defmodule Api.SessionActions do
   end
 
   def create(email, password) do
-    user = Repo.get_by(User, email: email)
+    Repo.get_by(User, email: email)
     |> check_password(password)
     |> sign_user
   end


### PR DESCRIPTION
Gets rid of this:
```
==> api
Compiling 53 files (.ex)
warning: variable "user" is unused
  web/actions/session_actions.ex:14
```