### PR TITLE
Change tie_breaker from count to max

### DIFF
--- a/lib/api_web/models/team.ex
+++ b/lib/api_web/models/team.ex
@@ -67,7 +67,12 @@ defmodule ApiWeb.Team do
   end
 
   defp generate_tie_breaker(repo) do
-    repo.aggregate(Team, :count, :id) + 1
+    max_tie_breaker = from(t in __MODULE__, select: max(t.tie_breaker)) |> repo.one()
+
+    case  max_tie_breaker do
+      nil -> 1
+      _ ->  max_tie_breaker + 1
+    end
   end
 
   def preference_hmac(team) do

--- a/test/models/team_test.exs
+++ b/test/models/team_test.exs
@@ -39,4 +39,15 @@ defmodule ApiWeb.TeamTest do
     second = Repo.insert!(Team.changeset(%Team{}, @valid_attrs, Repo))
     assert second.tie_breaker == 2
   end
+
+  test "tie_breaker doesn't break if team is deleted" do
+    first = Repo.insert!(Team.changeset(%Team{}, @valid_attrs, Repo))
+    Repo.insert!(Team.changeset(%Team{}, @valid_attrs, Repo))
+
+    Repo.delete(first)
+
+    third = Repo.insert!(Team.changeset(%Team{}, @valid_attrs, Repo))
+
+    assert third.tie_breaker == 3
+  end
 end


### PR DESCRIPTION
Tie breaker was defined by the count of teams + 1.
If there was 10 teams, and one team was deleted, the next tie breaker count would be 10 which already existed.

It was changed to be the max tie breaker present in a team + 1